### PR TITLE
ref: Make target error messages more useful

### DIFF
--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -162,23 +162,30 @@ describe('spawn', () => {
     }
   });
 
-  test('rejects and print args with options', async () => {
+  test('attaches args on error', async () => {
     try {
-      expect.assertions(3);
-      await spawn('test', ['x'], { cwd: 'file://yo.js' });
+      expect.assertions(1);
+      await spawn('test', ['x', 'y']);
     } catch (e) {
-      expect(e.message).toMatch(/ENOENT/);
-      expect(e.message).toMatch(/test "x"/);
-      expect(e.message).toMatch(/file:\/\/yo.js/);
+      expect(e.args).toEqual(['x', 'y']);
     }
   });
 
-  test('rejects and strip env from options', async () => {
+  test('attaches options on error', async () => {
     try {
       expect.assertions(1);
-      await spawn('test', [''], { env: { x: 123, password: 456 } });
+      await spawn('test', [], { cwd: 'file://yo.js' });
     } catch (e) {
-      expect(e.message.replace(/[\n\s]/g, '')).toMatch(/\["x","password"\]/);
+      expect(e.options).toEqual({ cwd: 'file://yo.js' });
+    }
+  });
+
+  test('strip env from options on error', async () => {
+    try {
+      expect.assertions(1);
+      await spawn('test', [], { env: { x: 123, password: 456 } });
+    } catch (e) {
+      expect(e.options.env).toEqual(['x', 'password']);
     }
   });
 });

--- a/lib/targets/pods.js
+++ b/lib/targets/pods.js
@@ -24,6 +24,11 @@ module.exports = async (context) => {
   const { logger, tag } = context;
   const { owner, repo } = context.repo();
 
+  if (!process.env.COCOAPODS_TRUNK_TOKEN) {
+    logger.warn('Skipping cocoapods release due to missing trunk token');
+    return;
+  }
+
   if (context.spec == null) {
     context.logger.error(`Missing podspec configuration for ${owner}/${repo}`);
     return;

--- a/lib/targets/pods.js
+++ b/lib/targets/pods.js
@@ -30,14 +30,14 @@ module.exports = async (context) => {
   }
 
   if (context.spec == null) {
-    context.logger.error(`Missing podspec configuration for ${owner}/${repo}`);
+    context.logger.warn(`Missing podspec configuration for ${owner}/${repo}`);
     return;
   }
 
   context.logger.info(`Loading podspec from ${owner}/${repo}:${context.spec}`);
   const spec = await getFile(context, context.spec, tag.ref);
   if (spec == null) {
-    context.logger.error(`Podspec not found at ${owner}/${repo}:${context.spec}`);
+    context.logger.warn(`Podspec not found at ${owner}/${repo}:${context.spec}`);
     return;
   }
 

--- a/lib/targets/pods.js
+++ b/lib/targets/pods.js
@@ -49,7 +49,6 @@ module.exports = async (context) => {
     context.logger.info(`Pushing podspec ${fileName} to cocoapods`);
     if (shouldPerform()) {
       const env = _.pick(process.env, ['COCOAPODS_TRUNK_TOKEN', 'PATH']);
-      await spawn(COCOAPODS_BIN, ['repo', 'update'], { cwd: directory, env });
       await spawn(COCOAPODS_BIN, ['trunk', 'push', fileName], { cwd: directory, env });
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -68,10 +68,9 @@ function cloneContext(context, params = {}) {
  *
  * @param {object} options Optional options passed to spawn
  */
-function convertOptionsForError(options = {}) {
+function stripEnv(options = {}) {
   const override = options.env && { env: Object.keys(options.env) };
-  const safeOptions = Object.assign({}, options, override);
-  return JSON.stringify(safeOptions, null, 2);
+  return Object.assign({}, options, override);
 }
 
 /**
@@ -84,13 +83,10 @@ function convertOptionsForError(options = {}) {
  * @returns {Error} The error with code
  */
 function processError(code, command, args, options) {
-  const error = new Error(
-    `Process errored with code ${code}\n` +
-    `Command: ${command} ${(args || []).map(a => JSON.stringify(a)).join(' ')}\n` +
-    `Options: ${convertOptionsForError(options)}`,
-  );
-
+  const error = new Error(`Process "${command}" errored with code ${code}`);
   error.code = code;
+  error.args = args;
+  error.options = stripEnv(options);
   return error;
 }
 


### PR DESCRIPTION
- Emit warnings instead of errors in some cases
 - Prevent pods invokation if the token is missing
 - Attach spawn errors with details to improve display on Sentry