### PR TITLE
fix: Compensate potential file system race conditions

### DIFF
--- a/lib/targets/pods.js
+++ b/lib/targets/pods.js
@@ -49,6 +49,7 @@ module.exports = async (context) => {
     context.logger.info(`Pushing podspec ${fileName} to cocoapods`);
     if (shouldPerform()) {
       const env = _.pick(process.env, ['COCOAPODS_TRUNK_TOKEN', 'PATH']);
+      await spawn(COCOAPODS_BIN, ['setup']);
       await spawn(COCOAPODS_BIN, ['trunk', 'push', fileName], { cwd: directory, env });
     }
 


### PR DESCRIPTION
Seems like the file system is just asynchronous enough for the pods
setup to not manifest before it tries to push the trunk. Thus, we
issue pods setup in a separate process to force a file system sync
before proceeding.