### PR TITLE
feat: Defer releases for one minute

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,16 @@ const STATE_SUCCESS = 'success';
 const CONFIG_NAME = 'release.yml';
 
 /**
+ * Time to wait before starting a release
+ */
+const RELEASE_TIMEOUT = 60000;
+
+/**
+ * Holds timeouts for deferred releases
+ */
+const scheduledReleases = {};
+
+/**
  * Internal cache for tags by repository
  */
 const tagCache = {};
@@ -274,7 +284,7 @@ async function releaseTarget(target, context, tag, files) {
 }
 
 /**
- * Handles a newly created or updated Github tag
+ * Releases build artifacts to all configured targets
  *
  * Downloads build artifacts from S3 and passes them to all configured release
  * targets, if any. In case no targets are configured, the download is skipped
@@ -283,6 +293,54 @@ async function releaseTarget(target, context, tag, files) {
  *
  * Only files from the local directory are uploaded; symlinks and folders
  * are skipped.
+ *
+ * @param {Context} context Github context
+ * @param {object} tag A tag object containing "ref" and "sha"
+ * @param {object} config Configurations for this task
+ * @returns A promise that resolves when the release has completed
+ * @async
+ */
+async function performRelease(context, tag, config) {
+  const { owner, repo } = context.repo();
+  logger.info(`Starting scheduled release of ${owner}/${repo}:${tag.ref}`);
+
+  await withTempDir(async (downloadDirectory) => {
+    const commitDirectory = `${owner}/${repo}/${tag.sha}`;
+    await downloadS3Directory(commitDirectory, downloadDirectory);
+    const files = await listFiles(downloadDirectory);
+    await Promise.all(config.targets.map(target => releaseTarget(target, context, tag, files)));
+  });
+}
+
+/**
+ * Schedules a deferred release to all configured targets
+ *
+ * If a release for the same tag has been scheduled, it is cancelled. This
+ * prevents repeated releases due to cascading or rapidly changing status
+ * checks reported by third party services (e.g. code coverage or CI).
+ *
+ * @param {Context} context Github context
+ * @param {object} tag A tag object containing "ref" and "sha"
+ * @param {object} config Configurations for this task
+ */
+function scheduleRelease(context, tag, config) {
+  const { owner, repo } = context.repo();
+  const id = `${owner}/${repo}:${tag.ref}`;
+
+  const scheduled = scheduledReleases[id];
+  if (scheduled != null) {
+    clearTimeout(scheduled);
+  }
+
+  logger.info(`Scheduling release of ${id} in ${RELEASE_TIMEOUT / 1000} seconds`);
+  scheduledReleases[id] = setTimeout(() => {
+    delete scheduledReleases[id];
+    performRelease(context, tag, config).catch(logger.error);
+  }, RELEASE_TIMEOUT);
+}
+
+/**
+ * Handles a newly created or updated Github tag
  *
  * If the tag has no status checks attached or some of them are still pending,
  * it is skipped. If at least one status check failed, an error is reported and
@@ -331,12 +389,7 @@ async function processTag(context, tag, config) {
   }
 
   // All checks have cleared, we're ready to release now
-  await withTempDir(async (downloadDirectory) => {
-    const commitDirectory = `${owner}/${repo}/${tag.sha}`;
-    await downloadS3Directory(commitDirectory, downloadDirectory);
-    const files = await listFiles(downloadDirectory);
-    await Promise.all(config.targets.map(target => releaseTarget(target, context, tag, files)));
-  });
+  scheduleRelease(context, tag, config);
 }
 
 module.exports = (robot) => {


### PR DESCRIPTION
Wait one minute before starting the actual release. This should compensate for jitter caused by CodeCov or cascading status checks.