### PR TITLE
feat: Implement homebrew releases

### DIFF
--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -29,6 +29,25 @@ describe('filterAsync', () => {
   });
 });
 
+describe('promiseProps', () => {
+  const { promiseProps } = require('../utils');
+
+  test('awaits an empty object', async () => {
+    const result = await promiseProps({});
+    expect(result).toEqual({});
+  });
+
+  test('awaits a plain object', async () => {
+    const result = await promiseProps({ foo: 'foo', bar: 42 });
+    expect(result).toEqual({ foo: 'foo', bar: 42 });
+  });
+
+  test('awaits an object with promises', async () => {
+    const result = await promiseProps({ foo: Promise.resolve('foo'), bar: Promise.resolve(42) });
+    expect(result).toEqual({ foo: 'foo', bar: 42 });
+  });
+});
+
 describe('isSorted', () => {
   const { isSorted } = require('../utils');
 

--- a/lib/targets/brew.js
+++ b/lib/targets/brew.js
@@ -1,0 +1,146 @@
+const crypto = require('crypto');
+const { shouldPerform } = require('dryrun');
+const { createReadStream } = require('fs');
+const _ = require('lodash');
+const { basename } = require('path');
+const { promiseProps } = require('../utils');
+
+/**
+ * Regex used to parse homebrew taps (github repositories)
+ */
+const TAP_REGEX = /^([a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38})\/([-_.\w\d]+)$/i;
+
+/**
+ * Extracts repository information for a homebrew tap from the given context
+ *
+ * If no explicit tap is given, 'homebrew/core' is assumed. Otherwise, the
+ * string "<owner>/>tap>" is transformed to "<owner>/homebrew-<tap>".
+ *
+ * @param {Context} context A github context
+ * @returns {object} The owner and repository of the tap
+ */
+function getTapRepo(context) {
+  const { tap } = context;
+  if (!tap) {
+    return {
+      owner: 'homebrew',
+      repo: 'homebrew-core',
+    };
+  }
+
+  const match = TAP_REGEX.exec(tap);
+  if (!match) {
+    throw new Error(`Invalid tap name: ${tap}`);
+  }
+
+  return {
+    owner: match[1],
+    repo: `homebrew-${match[2]}`,
+  };
+}
+
+/**
+ * Calculates the checksum of a file's contents
+ *
+ * @param {string} path The path to a file to process
+ * @param {string} algorithm A crypto algorithm, defaults to "sha256"
+ * @returns {Promise<string>} The checksum as hex string
+ * @async
+ */
+function calculateChecksum(path, algorithm = 'sha256') {
+  const stream = createReadStream(path);
+  const hash = crypto.createHash(algorithm);
+
+  return new Promise((resolve, reject) => {
+    stream.on('data', data => hash.update(data, 'utf8'));
+    stream.on('end', () => resolve(hash.digest('hex')));
+    stream.on('error', err => reject(err));
+  });
+}
+
+/**
+ * Resolves the content sha of a formula at the specified location. If the
+ * formula does not exist, `null` is returned.
+ *
+ * @param {Context} context A Github context
+ * @param {object} tap Owner and repository of the tap
+ * @param {string} path The path to the formula
+ * @returns {Promise<string>} The SHA of the file, if it exists; otherwise null
+ * @async
+ */
+async function getFormulaSha(context, tap, path) {
+  try {
+    context.logger.debug(`Loading SHA for ${tap.owner}/${tap.repo}:${path}`);
+    const response = await context.github.repos.getContent({ ...tap, path });
+    return response.data.sha;
+  } catch (err) {
+    if (err.code === 404) {
+      return null;
+    }
+
+    throw err;
+  }
+}
+
+/**
+ * Pushes a new formula to a homebrew tap
+ *
+ * @param {Context} context Enriched Github context
+ * @param {string[]} files Absolute paths to the build artifacts
+ * @returns {Promise} A promise that resolves when the release has finished
+ * @async
+ */
+module.exports = async (context, files) => {
+  const { formula, github, logger, path, tag, template } = context;
+  const { owner, repo } = context.repo();
+  const { ref, sha } = tag;
+
+  if (!template) {
+    throw new Error('Missing template parameter in "brew" target configuration.');
+  }
+
+  // Get default formula name and location from the config
+  const formulaName = formula || repo;
+  const formulaPath = (path == null)
+    ? `Formula/${formulaName}.rb`
+    : `${context.path}/${formulaName}.rb`;
+
+  // Format checksums and the tag version into the formula file
+  const fileMap = _.keyBy(files, file => basename(file));
+  const promises = _.mapValues(fileMap, file => calculateChecksum(file));
+  const checksums = await promiseProps(promises);
+  const data = _.template(template)({ ref, sha, checksums });
+  logger.debug(`Homebrew formula for ${formulaName}:\n${data}`);
+
+  // Try to find the repository to publish in
+  const tapRepo = getTapRepo(context);
+  if (tapRepo.owner !== owner) {
+    // TODO: Create a PR if we have no push rights to this repo
+    logger.warn('Skipping homebrew release: PRs not supported yet');
+    return;
+  }
+
+  const params = {
+    owner: tapRepo.owner,
+    repo: tapRepo.repo,
+    path: formulaPath,
+    message: `release: ${formula} ${ref}`,
+    content: new Buffer(data).toString('base64'),
+    sha: await getFormulaSha(context, tapRepo, formulaPath),
+  };
+
+  logger.info(`Releasing ${owner}/${repo} tag ${tag.ref} to homebrew tap ${tapRepo.owner}/${tapRepo.repo} formula ${formulaName}`);
+  if (params.sha == null) {
+    logger.debug(`Creating new file ${params.owner}/${params.repo}:${params.path}`);
+    if (shouldPerform()) {
+      github.repos.createFile(params);
+    }
+  } else {
+    logger.debug(`Updating file ${params.owner}/${params.repo}:${params.path} (${params.sha})`);
+    if (shouldPerform()) {
+      github.repos.updateFile(params);
+    }
+  }
+
+  logger.info('Homebrew release completed');
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const child = require('child_process');
+const _ = require('lodash');
 
 /**
  * Asynchronously calls the predicate on every element of the array and filters
@@ -13,6 +14,21 @@ const child = require('child_process');
 async function filterAsync(array, predicate, thisArg) {
   const verdicts = await Promise.all(array.map(predicate, thisArg));
   return array.filter((element, index) => verdicts[index]);
+}
+
+/**
+ * Returns a promise that resolves when each value of the given object resolves.
+ * Works just like `Promise.all`, just on objects.
+ *
+ * @param {object} object An object with one or more
+ * @returns {Promise<object>} A promise that resolves with each value
+ * @async
+ */
+async function promiseProps(object) {
+  const pairs = _.toPairs(object)
+    .map(async ([key, value]) => [key, await value]);
+
+  return _.fromPairs(await Promise.all(pairs));
 }
 
 /**
@@ -112,6 +128,7 @@ function spawn(command, args, options) {
 }
 
 module.exports = {
+  promiseProps,
   cloneContext,
   filterAsync,
   getFile,


### PR DESCRIPTION
Example configuration:

```yaml
targets:
  - github
  - name: brew
    tap: getsentry/tools
    template: >
      class SentryCli < Formula
        desc "This is a test for homebrew formulas"
        homepage "https://github.com/getsentry/probot-test"
        url "https://github.com/getsentry/probot-test/releases/download/${ref}/foo"
        version "${ref}"
        sha256 "${checksums.foo}"

        def install
          mv "foo", "probot-test"
          bin.install "probot-test"
        end

        test do
          assert_match version.to_s, shell_output("#{bin}/probot-test --version").chomp
        end
      end
```

For now only direct commits to the tap repository are supported.
In future versions, we could also create PRs