### PR TITLE
fix: Resolve commit hashes from annotated commits

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,9 +70,28 @@ async function getConfig(context) {
 }
 
 /**
+ * Resolves a git tag and returns the object it points to, most likely a commit
+ *
+ * This is especially useful when resolving annotated tags, as passing the tag's sha
+ * resolves the actual commit it points to.
+ *
+ * @param {Context} context Github context
+ * @param {string} sha The SHA of the tag to resolve
+ * @returns {Promise<object>} The tag object containing a "type" and "sha"
+ * @async
+ */
+async function getTagObject(context, sha) {
+  const params = context.repo({ sha });
+  const response = await context.github.gitdata.getTag(params);
+  return response.data.object;
+}
+
+/**
  * Resolves a git reference (e.g. branch or tag) and returns the object it points to
  *
- * Be sure to pass the entire reference name including its type, e.g.: "tags/v1.0.0".
+ * If the ref points to an annotated tag, the tag is resolved and the inner object is
+ * resolved instead. Be sure to pass the entire reference name including its type,
+ * e.g.: "tags/v1.0.0".
  *
  * @param {Context} context Github context
  * @param {String} ref The git reference to resolve
@@ -81,7 +100,13 @@ async function getConfig(context) {
 async function getReference(context, ref) {
   const params = context.repo({ ref });
   const response = await context.github.gitdata.getReference(params);
-  return response.data.object;
+
+  const { object } = response.data;
+  if (object.type === 'tag') {
+    return getTagObject(context, object.sha);
+  }
+
+  return object;
 }
 
 /**


### PR DESCRIPTION
For annotated tags, the `gitdata.getReferece` call only resolves us the inner
tag, and not the actual commit it points to. Therefore, we have to add another
indirection to fetch the actual commit before starting deployments.

This should solve a couple of issues, where releases tagged by NPM would not
be released to Github.