### PR TITLE
ref: Move target config into context.config prop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -254,7 +254,7 @@ function filterLatestStatuses(statuses) {
  * decide which artifacts will be included in the release.
  *
  * @param {object | string} target Target name or configuration
- * @param {Context} Github context
+ * @param {Context} context Github context
  * @param {object} tag A tag object containing "ref" and "sha"
  * @param {string[]} store A store bound to the commit
  * @returns {Promise} A promise that resolves when the release has succeeded
@@ -270,7 +270,7 @@ async function releaseTarget(target, context, tag, store) {
 
   try {
     const targetContext = cloneContext(context, {
-      ...config,
+      config,
       tag,
       logger,
       store,

--- a/lib/targets/brew.js
+++ b/lib/targets/brew.js
@@ -92,7 +92,7 @@ async function getFormulaSha(context, tap, path) {
  * @async
  */
 module.exports = async context => {
-  const { github, logger } = context;
+  const { config, github, logger } = context;
   const { formula, path, tag, template, store } = config;
   const { owner, repo } = context.repo();
   const { ref, sha } = tag;

--- a/lib/targets/brew.js
+++ b/lib/targets/brew.js
@@ -16,11 +16,11 @@ const TAP_REGEX = /^([a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38})\/([-_.\w\d]+)$/i;
  * If no explicit tap is given, 'homebrew/core' is assumed. Otherwise, the
  * string "<owner>/>tap>" is transformed to "<owner>/homebrew-<tap>".
  *
- * @param {Context} context A github context
+ * @param {object} config Configuration for the brew target
  * @returns {object} The owner and repository of the tap
  */
-function getTapRepo(context) {
-  const { tap } = context;
+function getTapRepo(config) {
+  const { tap } = config;
   if (!tap) {
     return {
       owner: 'homebrew',
@@ -69,9 +69,11 @@ function calculateChecksum(path, algorithm = 'sha256') {
  * @async
  */
 async function getFormulaSha(context, tap, path) {
+  const { logger, github } = context;
+
   try {
-    context.logger.debug(`Loading SHA for ${tap.owner}/${tap.repo}:${path}`);
-    const response = await context.github.repos.getContent({ ...tap, path });
+    logger.debug(`Loading SHA for ${tap.owner}/${tap.repo}:${path}`);
+    const response = await github.repos.getContent({ ...tap, path });
     return response.data.sha;
   } catch (err) {
     if (err.code === 404) {
@@ -85,27 +87,24 @@ async function getFormulaSha(context, tap, path) {
 /**
  * Pushes a new formula to a homebrew tap
  *
- * @param {Context} context Enriched Github context
+ * @param {TargetContext} context Enriched Github context
  * @returns {Promise} A promise that resolves when the release has finished
  * @async
  */
 module.exports = async context => {
-  const { formula, github, logger, path, tag, template, store } = context;
+  const { github, logger } = context;
+  const { formula, path, tag, template, store } = config;
   const { owner, repo } = context.repo();
   const { ref, sha } = tag;
 
   if (!template) {
-    throw new Error(
-      'Missing template parameter in "brew" target configuration.'
-    );
+    throw new Error('Missing template parameter in "brew" configuration');
   }
 
   // Get default formula name and location from the config
   const formulaName = formula || repo;
   const formulaPath =
-    path == null
-      ? `Formula/${formulaName}.rb`
-      : `${context.path}/${formulaName}.rb`;
+    path == null ? `Formula/${formulaName}.rb` : `${path}/${formulaName}.rb`;
 
   // Format checksums and the tag version into the formula file
   const files = await store.downloadAll();
@@ -116,7 +115,7 @@ module.exports = async context => {
   logger.debug(`Homebrew formula for ${formulaName}:\n${data}`);
 
   // Try to find the repository to publish in
-  const tapRepo = getTapRepo(context);
+  const tapRepo = getTapRepo(config);
   if (tapRepo.owner !== owner) {
     // TODO: Create a PR if we have no push rights to this repo
     logger.warn('Skipping homebrew release: PRs not supported yet');
@@ -133,10 +132,11 @@ module.exports = async context => {
   };
 
   logger.info(
-    `Releasing ${owner}/${repo} tag ${tag.ref} to homebrew tap ${
-      tapRepo.owner
-    }/${tapRepo.repo} formula ${formulaName}`
+    `Releasing ${owner}/${repo} tag ${tag.ref} ` +
+      `to homebrew tap ${tapRepo.owner}/${tapRepo.repo} ` +
+      `formula ${formulaName}`
   );
+
   if (params.sha == null) {
     logger.debug(
       `Creating new file ${params.owner}/${params.repo}:${params.path}`

--- a/lib/targets/github.js
+++ b/lib/targets/github.js
@@ -22,10 +22,10 @@ const CHANGELOG_PATH = 'CHANGELOG.md';
  * @async
  */
 async function getOrCreateRelease(context, tag) {
+  const { config, github, logger } = context;
+
   try {
-    const response = await context.github.repos.getReleaseByTag(
-      context.repo({ tag })
-    );
+    const response = await github.repos.getReleaseByTag(context.repo({ tag }));
     return response.data;
   } catch (err) {
     if (err.code !== 404) {
@@ -37,7 +37,7 @@ async function getOrCreateRelease(context, tag) {
 
   const changelog = await getFile(
     context,
-    context.changelog || CHANGELOG_PATH,
+    config.changelog || CHANGELOG_PATH,
     tag
   );
   const changes = changelog && findChangeset(changelog, tag);
@@ -50,17 +50,15 @@ async function getOrCreateRelease(context, tag) {
   });
 
   if (changes) {
-    context.logger.info(
-      `Found changelog for ${params.owner}/${params.repo}:${tag}`
-    );
+    logger.info(`Found changelog for ${params.owner}/${params.repo}:${tag}`);
   }
 
-  context.logger.info(`Creating release ${params.owner}/${params.repo}:${tag}`);
+  logger.info(`Creating release ${params.owner}/${params.repo}:${tag}`);
   if (!shouldPerform()) {
     return { id: 42, tag_name: tag, html_url: '[no url during DRY_RUN]' };
   }
 
-  const created = await context.github.repos.createRelease(params);
+  const created = await github.repos.createRelease(params);
   return created.data;
 }
 
@@ -76,7 +74,7 @@ async function getOrCreateRelease(context, tag) {
  * @async
  */
 module.exports = async context => {
-  const { logger, store, tag } = context;
+  const { github, logger, store, tag } = context;
   const release = await getOrCreateRelease(context, tag.ref);
 
   const files = await store.listFiles();
@@ -95,7 +93,7 @@ module.exports = async context => {
           release.tag_name
         }`
       );
-      return shouldPerform() ? context.github.repos.uploadAsset(params) : null;
+      return shouldPerform() ? github.repos.uploadAsset(params) : null;
     })
   );
 

--- a/lib/targets/npm.js
+++ b/lib/targets/npm.js
@@ -46,7 +46,7 @@ function publishPackage(path, access, logger) {
  * @async
  */
 module.exports = async context => {
-  const { access, logger, store } = context;
+  const { config, logger, store } = context;
 
   const files = await store.listFiles();
   const packageFile = files.find(file => PACKAGE_REGEX.test(file.name));
@@ -58,7 +58,7 @@ module.exports = async context => {
   const packagePath = await store.downloadFile(packageFile);
   logger.info(`Releasing ${packageFile.name} to NPM`);
   if (shouldPerform()) {
-    await publishPackage(packagePath, access, logger);
+    await publishPackage(packagePath, config.access, logger);
   }
 
   logger.info('NPM release completed');

--- a/lib/targets/pods.js
+++ b/lib/targets/pods.js
@@ -21,7 +21,7 @@ const COCOAPODS_BIN = process.env.COCOAPODS_BIN || 'pod';
  * @async
  */
 module.exports = async context => {
-  const { logger, tag } = context;
+  const { config, logger, tag } = context;
   const { owner, repo } = context.repo();
 
   if (!process.env.COCOAPODS_TRUNK_TOKEN) {
@@ -29,26 +29,24 @@ module.exports = async context => {
     return;
   }
 
-  if (context.spec == null) {
-    context.logger.warn(`Missing podspec configuration for ${owner}/${repo}`);
+  if (config.spec == null) {
+    logger.warn(`Missing podspec configuration for ${owner}/${repo}`);
     return;
   }
 
-  context.logger.info(`Loading podspec from ${owner}/${repo}:${context.spec}`);
-  const spec = await getFile(context, context.spec, tag.ref);
+  logger.info(`Loading podspec from ${owner}/${repo}:${config.spec}`);
+  const spec = await getFile(context, config.spec, tag.ref);
   if (spec == null) {
-    context.logger.warn(
-      `Podspec not found at ${owner}/${repo}:${context.spec}`
-    );
+    logger.warn(`Podspec not found at ${owner}/${repo}:${config.spec}`);
     return;
   }
 
   await withTempDir(async directory => {
-    const fileName = basename(context.spec);
+    const fileName = basename(config.spec);
     const filePath = join(directory, fileName);
     await writeFile(filePath, spec, 'utf8');
 
-    context.logger.info(`Pushing podspec ${fileName} to cocoapods`);
+    logger.info(`Pushing podspec ${fileName} to cocoapods`);
     if (shouldPerform()) {
       const env = _.pick(process.env, ['COCOAPODS_TRUNK_TOKEN', 'PATH']);
       await spawn(COCOAPODS_BIN, ['setup'], undefined, logger);


### PR DESCRIPTION
The configuration was previously merged with the cloned and enriched context,
which could easily lead to problems. Most importantly, however, this created
a strange target interface.

This PR nests all configuration inside `context.config`. Subsequently, all
targets have to be updated alongside:

```js
// before
module.exports = context => {
  const { foo, bar, github, logger } = context;
  // ...
};

// after
module.exports = context => {
  const { config, github, logger } = context;
  const { foo, bar } = config;
  // ...
};
```