### PR TITLE
feat: Allow to ignore status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,22 @@
   * [Testing](#testing)
 * [Deployment](#deployment)
 
-## Target Configuration
+## Configuration
 
 The bot will only be active in repositories that contain `.github/release.yml`.
 In these repositories it will listen for tags and start a release if all status
 checks associated to the tag's commit are successful. In case a commit has no
 status checks, the release is skipped.
+
+This file specifies release targets, stores and more:
+
+| Option          | Description                                                                     |
+| --------------- | ------------------------------------------------------------------------------- |
+| `store`         | **optional**. The store for release artifacts (see below).                      |
+| `targets`       | **optional**. List of release targets (see below).                              |
+| `ignoredChecks` | **optional**. A list of ignored status checks. Can be prefixes or entire names. |
+
+## Target Configuration
 
 The configuration specifies which release targets to run for the repository. To
 run more targets, list the target identifiers under the `target` key. If the

--- a/lib/index.js
+++ b/lib/index.js
@@ -232,13 +232,21 @@ async function getStatuses(context, ref) {
  * Removes all succeeded status checks from the given list
  *
  * Status checks are considered succeeded if there is another check with the
- * same "context", but a later "updated_at" value.
+ * same "context", but a later "updated_at" value. If the configuration
+ * specifies "ignoredChecks" then those status checks will be omitted from the
+ * list.
  *
  * @param {object[]} statuses A list of status checks
+ * @param {object} config Release configuration for the repository
  * @returns {object[]} The list of filtered status checks
  */
-function filterLatestStatuses(statuses) {
-  const statusesByContext = _.groupBy(statuses, status => status.context);
+function filterLatestStatuses(statuses, config) {
+  const ignoredChecks = config.ignoredChecks || [];
+  const filtered = statuses.filter(
+    status => !ignoredChecks.some(check => status.context.startsWith(check))
+  );
+
+  const statusesByContext = _.groupBy(filtered, status => status.context);
   return _.values(statusesByContext).map(context =>
     _.maxBy(context, status => status.updated_at)
   );
@@ -311,7 +319,7 @@ async function processTag(context, tag, config) {
   logger.info(`Processing tag ${id} (${tag.sha})`);
 
   const statuses = await getStatuses(context, tag.ref);
-  const latestStatuses = filterLatestStatuses(statuses);
+  const latestStatuses = filterLatestStatuses(statuses, config);
 
   // Prevent a previously scheduled release. In case this status update is
   // successful again, we will reschedule down below.


### PR DESCRIPTION
This will allow to skip checking docker cloud for sentry-cli:

```yaml
store: s3
targets:
 - github
 - pypi
ignoredChecks:
 - ci/dockercloud
```